### PR TITLE
Resolving django deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: python
-python: 2.7
+python:
+  - 3.5
 install:
   - pip install tox
 env:
-  - TOXENV=py26-django1.4
-  - TOXENV=py26-django1.5
-  - TOXENV=py26-django1.6
-  - TOXENV=py27-django1.4
-  - TOXENV=py27-django1.5
-  - TOXENV=py27-django1.6
-  - TOXENV=py33-django1.5
-  - TOXENV=py33-django1.6
+  - TOXENV=py27-django1.8
+  - TOXENV=py35-django1.8
   - TOXENV=coverage
 script:
   - tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 env:
   - TOXENV=py27-django1.8
   - TOXENV=py35-django1.8
+  - TOXENV=py35-django1.11
   - TOXENV=coverage
 script:
   - tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
 env:
   - TOXENV=py27-django1.8
   - TOXENV=py35-django1.8
-  - TOXENV=py35-django1.11
   - TOXENV=coverage
 script:
   - tox -e $TOXENV

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,8 @@
 from distutils.core import setup
 
-# Dynamically calculate the version based on tagging.VERSION.
-version_tuple = __import__('voting').VERSION
-if version_tuple[2] is not None:
-    version = "%d.%d_%s" % version_tuple
-else:
-    version = "%d.%d" % version_tuple[:2]
-
 setup(
     name='django-voting',
-    version=version,
+    version='0.2.1',
     description='Generic voting application for Django',
     author='Jonathan Buchanan',
     author_email='jonathan.buchanan@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py27-django1.8
     py35-django1.8
+    py35-django1.11
     coverage
 
 [testenv]
@@ -28,3 +29,8 @@ deps =
 basepython = python3.5
 deps =
     Django>=1.8,<1.9
+
+[testenv:py35-django1.11]
+basepython = python3.5
+deps =
+    Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py27-django1.8
     py35-django1.8
-    py35-django1.11
     coverage
 
 [testenv]
@@ -29,8 +28,3 @@ deps =
 basepython = python3.5
 deps =
     Django>=1.8,<1.9
-
-[testenv:py35-django1.11]
-basepython = python3.5
-deps =
-    Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,7 @@
 [tox]
 envlist =
-    py26-django1.4,
-    py26-django1.5,
-    py26-django1.6,
-    py27-django1.4,
-    py27-django1.5,
-    py27-django1.6,
-    py33-django1.5,
-    py33-django1.6,
+    py27-django1.8
+    py35-django1.8
     coverage
 
 [testenv]
@@ -22,45 +16,15 @@ basepython = python2.7
 commands =
     coverage run --branch --omit=.tox/*,*/tests/*.py,*/migrations/*.py {envbindir}/django-admin.py test voting
 deps =
-    coverage>=3.7,
-    Django>=1.6,<1.7
+    coverage>=3.7
+    Django>=1.8,<1.9
 
-[testenv:py26-django1.4]
-basepython = python2.6
-deps =
-    Django>=1.4.2,<1.5
-
-[testenv:py26-django1.5]
-basepython = python2.6
-deps =
-    Django>=1.5,<1.6
-
-[testenv:py26-django1.6]
-basepython = python2.6
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py27-django1.4]
+[testenv:py27-django1.8]
 basepython = python2.7
 deps =
-    Django>=1.4.2,<1.5
+    Django>=1.8,<1.9
 
-[testenv:py27-django1.5]
-basepython = python2.7
+[testenv:py35-django1.8]
+basepython = python3.5
 deps =
-    Django>=1.5,<1.6
-
-[testenv:py27-django1.6]
-basepython = python2.7
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py33-django1.5]
-basepython = python3.3
-deps =
-    Django>=1.5,<1.6
-
-[testenv:py33-django1.6]
-basepython = python3.3
-deps =
-    Django>=1.6,<1.7
+    Django>=1.8,<1.9

--- a/voting/__init__.py
+++ b/voting/__init__.py
@@ -1,1 +1,0 @@
-VERSION = (0, 2, None)

--- a/voting/models.py
+++ b/voting/models.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from django.utils.encoding import python_2_unicode_compatible
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
 from django.db import models
@@ -31,7 +31,7 @@ class Vote(models.Model):
     user = models.ForeignKey(User)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
-    object = generic.GenericForeignKey('content_type', 'object_id')
+    object = GenericForeignKey('content_type', 'object_id')
     vote = models.SmallIntegerField(choices=SCORES)
     time_stamp = models.DateTimeField(editable=False, default=now)
 


### PR DESCRIPTION
Resolves GenericForeignKey import deprecation.
Also reduces the tox test suite to our intended supported versions.

Django 1.11 has not been added to tox here in the end due to the need to migrate (heh) away from South. That should be resolved as a separate PR.