### PR TITLE
Remove deprecated resolve_variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-voting',
-    version='0.2.2',
+    version='0.3.1',
     description='Generic voting application for Django',
     author='Jonathan Buchanan',
     author_email='jonathan.buchanan@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-voting',
-    version='0.2.1',
+    version='0.2.2',
     description='Generic voting application for Django',
     author='Jonathan Buchanan',
     author_email='jonathan.buchanan@gmail.com',

--- a/voting/templatetags/voting_tags.py
+++ b/voting/templatetags/voting_tags.py
@@ -19,7 +19,7 @@ class ScoreForObjectNode(template.Node):
 
     def render(self, context):
         try:
-            object = template.resolve_variable(self.object, context)
+            object = template.Variable(self.object).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_score(object)
@@ -33,7 +33,7 @@ class ScoresForObjectsNode(template.Node):
 
     def render(self, context):
         try:
-            objects = template.resolve_variable(self.objects, context)
+            objects = template.Variable(self.objects).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_scores_in_bulk(objects)
@@ -48,8 +48,8 @@ class VoteByUserNode(template.Node):
 
     def render(self, context):
         try:
-            user = template.resolve_variable(self.user, context)
-            object = template.resolve_variable(self.object, context)
+            user = template.Variable(self.user).resolve(context)
+            object = template.Variable(self.object).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_for_user(object, user)
@@ -64,8 +64,8 @@ class VotesByUserNode(template.Node):
 
     def render(self, context):
         try:
-            user = template.resolve_variable(self.user, context)
-            objects = template.resolve_variable(self.objects, context)
+            user = template.Variable(self.user).resolve(context)
+            objects = template.Variable(self.objects).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_for_user_in_bulk(objects, user)
@@ -80,8 +80,8 @@ class DictEntryForItemNode(template.Node):
 
     def render(self, context):
         try:
-            dictionary = template.resolve_variable(self.dictionary, context)
-            item = template.resolve_variable(self.item, context)
+            dictionary = template.Variable(self.dictionary).resolve(context)
+            item = template.Variable(self.item).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = dictionary.get(item.id, None)

--- a/voting/views.py
+++ b/voting/views.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import get_model
+from django.apps import apps
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, \
     HttpResponseRedirect
 from django.contrib.auth.views import redirect_to_login
@@ -114,7 +114,7 @@ def vote_on_object_with_lazy_model(request, app_label, model_name, *args,
     Returns HTTP 400 (Bad Request) if there is no model matching the app_label
     and model_name.
     """
-    model = get_model(app_label, model_name)
+    model = apps.get_model(app_label, model_name)
     if not model:
         return HttpResponseBadRequest('Model %s.%s does not exist' % (
             app_label, model_name))


### PR DESCRIPTION
# Remove deprecated `resolve_variable`
_This PR removes the deprecated `resolve_variable` usage and it fixes the import of `get_model` in order to get it to work with Django 1.11._

* Bump up version to v0.2.2
* Import `get_model` from `django.apps` instead of the deprecated `django.db.models`.
* Replace deprecated `resolve_variable` with new structured call